### PR TITLE
Correct link to CLI Download Website

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This example is part of the [OmnAIView](https://github.com/AI-Gruppe/OmnAIView) 
 This project works with all OmnAI compatible Data-Sources. 
 Two prominent ones being:
 1) [OmnAIView-DevDataServer](https://github.com/AI-Gruppe/OmnAIView-DevDataServer)
-2) [OmnAI-CLI Tool](omnaiscope.auto-intern.de/download)
+2) [OmnAI-CLI Tool](https://omnaiscope.auto-intern.de/download)
 
 ### DevDataServer
 Set up the DevDataServer according to its [own README.md](https://github.com/AI-Gruppe/OmnAIView-DevDataServer/blob/master/README.md)


### PR DESCRIPTION
Hi everyone, 

This PR corrects the external link to the official CLI download page in the README.md. The previous link was either broken or outdated. With this fix, users can reliably access the correct CLI installation source.

## What problem does this PR solve?

## Which concept, bug, or requirement does it address?
It addresses a documentation issue that could lead to user confusion or failed installations. The CLI link in the README was incorrect, which affects onboarding and developer experience. Fixing this improves usability and reduces friction for new users.

## Design Decisions
No changes to the application logic or structure were made. Only the Markdown link was updated in the README.md to point to the correct CLI resource.

## Which are the main files and concepts you changed or introduced?
README.md: Fixed the incorrect external link to the CLI installation page.
@AKMaily 

Best wishes,

Nick